### PR TITLE
Copy script to pull and setup repos in VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,4 +35,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "katuma-dev" => ["default"]
     }
   end
+
+  config.vm.provision "file", source: "setup_repos.sh", destination: "~/setup_repos.sh"
 end

--- a/setup_repos.sh
+++ b/setup_repos.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd $HOME
+git clone git@github.com:coopdevs/katuma.git
+cd katuma
+bundle install
+bundle exec rake db:setup
+
+cd $HOME
+git clone git@github.com:coopdevs/katuma-web.git
+cd katuma-web
+yarn install


### PR DESCRIPTION
This copies the setup_repos.sh in the HOME as part of the provisioning, then you need to ssh into the machine and execute it.

It pulls both katuma and katuma-web repos and install their dependencies, including
setting up the database with its seed data.

This makes trivial setting up the environment and so easier for others to join the project. We can remove steps from the wiki! 🎉 

- [ ] Update the wiki once merged.