### PR TITLE
Map port 3000 to be used by Rails

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,10 +9,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'ubuntu/xenial64'
   config.vm.box_version = '20161026.0.0'
   config.vm.box_check_update = false
+
   # node.js
   config.vm.network 'forwarded_port', guest: 8000, host: 8000
   # webpack dev server for css and js
   config.vm.network 'forwarded_port', guest: 3001, host: 3001
+  # rails
+  config.vm.network 'forwarded_port', guest: 3000, host: 3000
+
 
   # Not setting hostname for now since Vagrant will restart container interface
   # enabling DHCP again


### PR DESCRIPTION
Apparently there was no port dedicated to Rails and so direct requests to the rails app can't be made from the host machine.

This could provide useful when debugging the API. Honestly, first thing I do is open 0.0.0.0:3000 on my browser to ensure the rails app is reachable from the host. Do you guys agree on keeping it?